### PR TITLE
Add index error for goto card out of bounds

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -604,6 +604,9 @@ class Runner():
                 if m.GetProperty("name") == cardName:
                     index = self.stackManager.stackModel.childModels.index(m)
         if index is not None:
+            if index > len(self.stackManager.stackModel.childModels):
+                # Modify index back to 1 based for user visible error message
+                raise ValueError(f'card number {index + 1} does not exist')
             self.stackManager.LoadCardAtIndex(index)
         else:
             raise ValueError("cardName '" + cardName + "' does not exist")

--- a/runner.py
+++ b/runner.py
@@ -604,7 +604,7 @@ class Runner():
                 if m.GetProperty("name") == cardName:
                     index = self.stackManager.stackModel.childModels.index(m)
         if index is not None:
-            if index > len(self.stackManager.stackModel.childModels):
+            if index >= len(self.stackManager.stackModel.childModels):
                 # Modify index back to 1 based for user visible error message
                 raise ValueError(f'card number {index + 1} does not exist')
             self.stackManager.LoadCardAtIndex(index)


### PR DESCRIPTION
*Summary*
Prior to this change, using GotoCard with an out of bounds index
resulted in a python backtrace, hard-to-read (for new programmers)
error, and the error *not* being added to the errors buffer (because it
happened on main thread). After the change, error message is descriptive
and added to errors buffer.

*Test Plan*
To reproduce, simply use GotoCard(100) in an event handler in the
default/readme stack